### PR TITLE
Fix open file handles in TrueZIP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,21 +83,6 @@
       <version>0.1.51</version>
     </dependency>
     <dependency>
-      <groupId>de.schlichtherle.truezip</groupId>
-      <artifactId>truezip-driver-zip</artifactId>
-      <version>7.7.9</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.bouncycastle</groupId>
-          <artifactId>bcprov-jdk15on</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>de.schlichtherle.truezip</groupId>
-          <artifactId>truezip-swing</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch.agentproxy.core</artifactId>
       <version>0.0.7</version>


### PR DESCRIPTION
The old implementation of WarEngine#updateWarFile() does not close all open
file handles which could lead to out of memory errors.

The new implementation fixes the open file handles and removed the dependency
to TrueZIP. It uses JDK 7 feature ZipFileSystemProvider to append the lavender
files to the war file. It is slightly less performant compared to the old
implementation using TrueZIP (~40ms with TrueZIP vs ~140ms with
ZipFileSystemProvider).

Please verify the changes.
