### PR TITLE
Use production and development filter in test environment

### DIFF
--- a/src/main/java/net/oneandone/lavender/filter/FilterList.java
+++ b/src/main/java/net/oneandone/lavender/filter/FilterList.java
@@ -1,0 +1,62 @@
+package net.oneandone.lavender.filter;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Holds a list of servlet filters which are called in a chain. The execution order is the list order
+ */
+public class FilterList implements Filter {
+
+    private final List<Filter> filters;
+
+    public FilterList(final List<Filter> filters) {
+        if (filters == null) {
+            throw new NullPointerException("Filter list must not be null");
+        } else if (filters.isEmpty()) {
+            throw new NullPointerException("Filter list must not be empty");
+        }
+        this.filters = new CopyOnWriteArrayList<>(filters);
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        for (Filter filter : filters) {
+            filter.init(filterConfig);
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (filters.size() == 1) {
+            filters.get(0).doFilter(request, response, chain);
+        } else {
+            createFilterListChain(chain).doFilter(request, response);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        for (Filter filter : filters) {
+            filter.destroy();
+        }
+    }
+
+    public List<Filter> getFilters() {
+        return new ArrayList<>(filters);
+    }
+
+    FilterListChain createFilterListChain(FilterChain chain) {
+        return new FilterListChain(filters, chain);
+    }
+
+}

--- a/src/main/java/net/oneandone/lavender/filter/FilterListChain.java
+++ b/src/main/java/net/oneandone/lavender/filter/FilterListChain.java
@@ -1,0 +1,37 @@
+package net.oneandone.lavender.filter;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Created by sfelis on 9/28/16.
+ */
+public class FilterListChain implements FilterChain {
+
+    private final List<Filter> filters;
+
+    private final FilterChain delegate;
+
+    private int currentFilterIndex = 0;
+
+    public FilterListChain(List<Filter> filters, FilterChain delegate) {
+        this.filters = filters;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response)
+            throws IOException, ServletException {
+
+        if (currentFilterIndex < filters.size()) {
+            filters.get(currentFilterIndex++).doFilter(request, response, this);
+        } else {
+            delegate.doFilter(request, response);
+        }
+    }
+}

--- a/src/test/java/net/oneandone/lavender/filter/FilterListChainTest.java
+++ b/src/test/java/net/oneandone/lavender/filter/FilterListChainTest.java
@@ -1,0 +1,117 @@
+package net.oneandone.lavender.filter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Created by sfelis on 9/28/16.
+ */
+public class FilterListChainTest {
+
+    @Mock
+    private FilterConfig filterConfigMock;
+
+    @Mock
+    private Filter filterAMock;
+
+    @Mock
+    private Filter filterBMock;
+
+    @Mock
+    private ServletRequest requestMock;
+
+    @Mock
+    private ServletResponse responseMock;
+
+    @Mock
+    private FilterChain chainMock;
+
+    @Mock
+    private FilterListChain filterListChainMock;
+
+    private List<Filter> filters;
+
+    @Before
+    public void setUp () {
+        MockitoAnnotations.initMocks(this);
+
+        filters = new ArrayList<>();
+        filters.add(filterAMock);
+        filters.add(filterBMock);
+    }
+
+    @Test
+    public void doFilterShouldCallOriginalFilterChain() throws Exception {
+        FilterListChain filterListChain = new FilterListChain(filters, chainMock);
+        doAnswer(mockDoFilterCall()).when(filterAMock).doFilter(any(), any(), any());
+        doAnswer(mockDoFilterCall()).when(filterBMock).doFilter(any(), any(), any());
+
+
+        filterListChain.doFilter(requestMock, responseMock);
+
+
+        verify(filterAMock, times(1)).doFilter(eq(requestMock), eq(responseMock), eq(filterListChain));
+        verify(filterBMock, times(1)).doFilter(eq(requestMock), eq(responseMock), eq(filterListChain));
+        verify(chainMock, times(1)).doFilter(eq(requestMock), eq(responseMock));
+    }
+
+    @Test
+    public void doFilterShouldNotCallOriginalFilterChain() throws Exception {
+        FilterListChain filterListChain = new FilterListChain(filters, chainMock);
+        doAnswer(mockDoFilterCall()).when(filterAMock).doFilter(any(), any(), any());
+
+
+        filterListChain.doFilter(requestMock, responseMock);
+
+
+        verify(filterAMock, times(1)).doFilter(eq(requestMock), eq(responseMock), eq(filterListChain));
+        verify(filterBMock, times(1)).doFilter(eq(requestMock), eq(responseMock), eq(filterListChain));
+        verify(chainMock, times(0)).doFilter(eq(requestMock), eq(responseMock));
+    }
+
+    @Test
+    public void doFilterShouldNotCallFilterB() throws Exception {
+        FilterListChain filterListChain = new FilterListChain(filters, chainMock);
+
+
+        filterListChain.doFilter(requestMock, responseMock);
+
+
+        verify(filterAMock, times(1)).doFilter(eq(requestMock), eq(responseMock), eq(filterListChain));
+        verify(filterBMock, times(0)).doFilter(eq(requestMock), eq(responseMock), eq(filterListChain));
+        verify(chainMock, times(0)).doFilter(eq(requestMock), eq(responseMock));
+    }
+
+    private Answer mockDoFilterCall() {
+        return new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+                ServletRequest request = (ServletRequest) invocationOnMock.getArguments()[0];
+                ServletResponse response = (ServletResponse) invocationOnMock.getArguments()[1];
+                FilterChain chain = (FilterChain) invocationOnMock.getArguments()[2];
+                chain.doFilter(request, response);
+                return null;
+            }
+        };
+    }
+
+}

--- a/src/test/java/net/oneandone/lavender/filter/FilterListTest.java
+++ b/src/test/java/net/oneandone/lavender/filter/FilterListTest.java
@@ -1,0 +1,112 @@
+package net.oneandone.lavender.filter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by sfelis on 9/28/16.
+ */
+public class FilterListTest {
+
+    @Mock
+    private FilterConfig filterConfigMock;
+
+    @Mock
+    private Filter filterAMock;
+
+    @Mock
+    private Filter filterBMock;
+
+    @Mock
+    private ServletRequest requestMock;
+
+    @Mock
+    private ServletResponse responseMock;
+
+    @Mock
+    private FilterChain chainMock;
+
+    @Mock
+    private FilterListChain filterListChainMock;
+
+    private List<Filter> filters;
+
+    @Before
+    public void setUp () {
+        MockitoAnnotations.initMocks(this);
+
+        filters = new ArrayList<>();
+        filters.add(filterAMock);
+        filters.add(filterBMock);
+    }
+
+    @Test
+    public void init() throws ServletException {
+        FilterList filterList = new FilterList(filters);
+
+
+        filterList.init(filterConfigMock);
+
+
+        verify(filterAMock, times(1)).init(eq(filterConfigMock));
+        verify(filterBMock, times(1)).init(eq(filterConfigMock));
+    }
+
+    @Test
+    public void doFilter() throws IOException, ServletException {
+        FilterList filterList = new FilterList(filters);
+        FilterList filterListSpy = Mockito.spy(filterList);
+        when(filterListSpy.createFilterListChain(any())).thenReturn(filterListChainMock);
+
+
+        filterListSpy.doFilter(requestMock, responseMock, chainMock);
+
+
+        verify(filterListChainMock, times(1)).doFilter(eq(requestMock), eq(responseMock));
+    }
+
+    @Test
+    public void doFilterWithOneFilterShouldCallFilterDirectly() throws IOException, ServletException {
+        filters = new ArrayList<>();
+        filters.add(filterAMock);
+        FilterList filterList = new FilterList(filters);
+        FilterList filterListSpy = Mockito.spy(filterList);
+
+
+        filterListSpy.doFilter(requestMock, responseMock, chainMock);
+
+
+        verify(filterAMock, times(1)).doFilter(eq(requestMock), eq(responseMock), eq(chainMock));
+    }
+
+    @Test
+    public void destroy() throws ServletException {
+        FilterList filterList = new FilterList(filters);
+
+
+        filterList.destroy();
+
+
+        verify(filterAMock, times(1)).destroy();
+        verify(filterBMock, times(1)).destroy();
+    }
+}

--- a/src/test/java/net/oneandone/lavender/filter/LavenderTest.java
+++ b/src/test/java/net/oneandone/lavender/filter/LavenderTest.java
@@ -30,9 +30,15 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class LavenderTest {
@@ -101,6 +107,32 @@ public class LavenderTest {
 
         assertFalse(lavenderFilterSpy.getProd());
         assertEquals(5, lavenderFilterSpy.getModules());
+    }
+
+    @Test
+    public void initShouldUseProductionAndDevelopmentFilter() throws Exception {
+        givenFile(Lavender.LAVENDER_IDX);
+        givenFile(Lavender.LAVENDER_NODES, "http://s1.uicdn.net/m1", "https://s1.uicdn.net/m1");
+
+        when(servletContext.getInitParameter(eq("mode"))).thenReturn("test");
+
+        ProductionFilter productionFilterMock = mock(ProductionFilter.class);
+
+        DevelopmentFilter developmentFilterMock = mock(DevelopmentFilter.class);
+        Mockito.when(developmentFilterMock.getModulesCount()).thenReturn(5);
+
+        Lavender lavenderFilterSpy = Mockito.spy(lavenderFilter);
+        doReturn(productionFilterMock).when(lavenderFilterSpy).createProductionFilter();
+        doReturn(developmentFilterMock).when(lavenderFilterSpy).createDevelopmentFilter();
+
+
+        lavenderFilterSpy.init(filterConfig);
+
+
+        assertFalse(lavenderFilterSpy.getProd());
+        assertEquals(5, lavenderFilterSpy.getModules());
+        verify(productionFilterMock, times(1)).init(any());
+        verify(developmentFilterMock, times(1)).init(any());
     }
 
     private void givenFile(String filename, String... lines) throws IOException {


### PR DESCRIPTION
The production filter rewrites the HTML output and replaces CDN
resources references. This filter is used in production.

The development filter resolves image paths to local, jar dependencies,
or remote paths, such as subversion urls. A remote resource is download
and served by the filter.

Up to now, the requirements were to serve either the production
(exclusive) or the development filter. New feature requrests make this
assumption void.

The new requirement is that in development environment the application
might use both, the HTML rewrite for external CDN resources and the
image resolving at the same time. Therefore, the development mode uses
the production filter as well.

The development mode is detected by the ServletContext parameter 'mode'.
If the value is 'test', the development mode with development filter
and production filter (if lavender index and lavender nodes are present)
is instanciated.
