### PR TITLE
rewrite img/@srcset and source/@srcset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * update lazy-foss-parent 1.0.4 to 1.2.0
 * checkstyle fixes
 * IntelliJ code inspection fixes
+* rewrite img/@srcset and source/@srcset
 
 
 ### 2.7.1 (2018-11-22)

--- a/src/main/java/net/oneandone/lavender/filter/processor/LavenderHtmlAttribute.java
+++ b/src/main/java/net/oneandone/lavender/filter/processor/LavenderHtmlAttribute.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 public enum LavenderHtmlAttribute implements HtmlAttribute {
 
     SRC("src"),
+    SRCSET("srcset"),
     HREF("href"),
     REL("rel"),
     STYLE("style"),

--- a/src/main/java/net/oneandone/lavender/filter/processor/LavenderUrlRewriteMatcher.java
+++ b/src/main/java/net/oneandone/lavender/filter/processor/LavenderUrlRewriteMatcher.java
@@ -23,6 +23,7 @@ import static net.oneandone.lavender.filter.processor.LavenderHtmlAttribute.DATA
 import static net.oneandone.lavender.filter.processor.LavenderHtmlAttribute.HREF;
 import static net.oneandone.lavender.filter.processor.LavenderHtmlAttribute.REL;
 import static net.oneandone.lavender.filter.processor.LavenderHtmlAttribute.SRC;
+import static net.oneandone.lavender.filter.processor.LavenderHtmlAttribute.SRCSET;
 import static net.oneandone.lavender.filter.processor.LavenderHtmlAttribute.TYPE;
 import static net.oneandone.lavender.filter.processor.LavenderHtmlTag.A;
 import static net.oneandone.lavender.filter.processor.LavenderHtmlTag.FORM;
@@ -36,11 +37,13 @@ import static net.oneandone.lavender.filter.processor.LavenderHtmlTag.SOURCE;
 public enum LavenderUrlRewriteMatcher implements UrlRewriteMatcher {
 
     IMG_MATCHER(SRC, p -> p.getTag() == IMG, true),
+    IMG_SOURCESET_MATCHER(SRCSET, p -> p.getTag() == IMG, false),
     LINK_MATCHER(HREF, p -> p.getTag() == LINK && Arrays.asList("stylesheet", "icon", "shortcut icon").contains(p.getAttribute(REL)), false),
     SCRIPT_MATCHER(SRC, p -> p.getTag() == SCRIPT && (("text/javascript".equals(p.getAttribute(TYPE))) || !p.containsAttribute(TYPE)), false),
     INPUT_MATCHER(SRC, p -> p.getTag() == INPUT && "image".equals(p.getAttribute(TYPE)), false),
     A_MATCHER(HREF, p -> p.getTag() == A, false),
     SOURCE_MATCHER(SRC, p -> p.getTag() == SOURCE, false),
+    SOURCE_SOURCESET_MATCHER(SRCSET, p -> p.getTag() == SOURCE, false),
     FORM_MATCHER(ACTION, p -> p.getTag() == FORM, false),
     IFRAME_MATCHER(SRC, p -> p.getTag() == IFRAME, false),
     DATA_LAVENDER_MATCHER(DATA_LAVENDER_ATTR, p -> true, false);

--- a/src/test/java/net/oneandone/lavender/filter/processor/HtmlProcessorTest.java
+++ b/src/test/java/net/oneandone/lavender/filter/processor/HtmlProcessorTest.java
@@ -73,6 +73,18 @@ public class HtmlProcessorTest {
     }
 
     @Test
+    public void testHtml5SourceSet() throws IOException {
+
+        String input = "<img src='/x/y/z' srcset='/x/y/z, /x/y/z 640w,\n /x/y/z 2.0x, data:AAAA'/>";
+        String expected = "<img src='http://a.b.c' srcset='http://a.b.c, http://a.b.c 640w,\n http://a.b.c 2.0x, data:AAAA'/>";
+
+        processor.process(input, 0, input.length());
+        processor.flush();
+
+        assertEquals(expected, out.getBuffer().toString());
+    }
+
+    @Test
     public void testDataLavenderAttributes() throws IOException {
         String input = "<a src='/x/y/z' data-lavender-a='x/y/z' data-lavender-2='x/y/z' >";
         String output = "<a src='/x/y/z' data-lavender-a='http://a.b.c' data-lavender-2='http://a.b.c' >";


### PR DESCRIPTION
We want to use the "srcset" attribute for [Responsive Images](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). This PR adds support to Lavender for rewriting URLs given in this attribute.