### PR TITLE
Keep query parameters when lavendelizing links

### DIFF
--- a/src/main/java/net/oneandone/lavender/filter/processor/LavenderRewriteEngine.java
+++ b/src/main/java/net/oneandone/lavender/filter/processor/LavenderRewriteEngine.java
@@ -148,10 +148,14 @@ public class LavenderRewriteEngine implements RewriteEngine {
             return reference;
         }
 
-        return calculateURL(label, baseURI);
+        return calculateURL(label, baseURI, reference.getQuery());
     }
 
     public URI calculateURL(Label label, URI baseURI) {
+        return calculateURL(label, baseURI, null);
+    }
+
+    public URI calculateURL(Label label, URI baseURI, String query) {
         if (label.getLavendelizedPath() == null) {
             throw new IllegalStateException();
         }
@@ -162,7 +166,7 @@ public class LavenderRewriteEngine implements RewriteEngine {
         String path = nodeURI.getPath() + lavendelizedPath;
         int port = nodeURI.getPort();
         try {
-            return new URI(nodeURI.getScheme(), null, node, port, path, null, null);
+            return new URI(nodeURI.getScheme(), null, node, port, path, query, null);
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }

--- a/src/test/java/net/oneandone/lavender/filter/it/LavendelizerIT.java
+++ b/src/test/java/net/oneandone/lavender/filter/it/LavendelizerIT.java
@@ -91,6 +91,7 @@ public class LavendelizerIT {
         assertTrue(content.contains("http://lavendel3.local/lavender/app/5c4990d0d465809ca15232cc7b190583-ie6.css"));
         assertTrue(content.contains("http://lavendel1.local/lavender/app/ae01e2f698490a0c137018c5dcf07d4c-ie7.css"));
         assertTrue(content.contains("http://lavendel1.local/lavender/app/75d5b048491003744336d32a78154449-logo.png"));
+        assertTrue(content.contains("http://lavendel1.local/lavender/app/75d5b048491003744336d32a78154449-logo.png?param=value"));
         assertTrue(content.contains("http://lavendel1.local/lavender/app/e4ccf35257829c23b8e31e16619289ba-background.png"));
         assertTrue(content.contains("http://lavendel3.local/lavender/app/3dcdd67e7205534e2f7ad7c41683dc40-main.js"));
 

--- a/src/test/java/net/oneandone/lavender/filter/processor/LavenderRewriteEngineTest.java
+++ b/src/test/java/net/oneandone/lavender/filter/processor/LavenderRewriteEngineTest.java
@@ -58,6 +58,11 @@ public class LavenderRewriteEngineTest {
     }
 
     @Test
+    public void rewritePreservesQueryParameter() {
+        assertEquals("http://s1.cdn.net/out.jpg?param=1", engine.rewrite("http://localhost:80/in.jpg?param=1", URI.create("http://localhost:80"), "/"));
+    }
+
+    @Test
     public void rewriteImplicitProtocol() {
         assertEquals("http://s1.cdn.net/out.jpg", engine.rewrite("//localhost:80/in.jpg", URI.create("http://localhost:80"), "/"));
     }

--- a/src/test/testapp1/webapp/page.html
+++ b/src/test/testapp1/webapp/page.html
@@ -45,6 +45,7 @@ var A='abc';
 <img src="logo.png" alt="abc" height="58" width="58">
 <img src="logo.png" alt="abc" height="58" width="58">
 <img src="logo.png" alt="abc" height="58" width="58">
+<img src="logo.png?param=value" alt="abc" height="58" width="58">
 
 
 <!-- embedded styles -->


### PR DESCRIPTION
Our UI team wants to pass query parameters when referencing SVG files. When using Lavender with these SVG files, the query string was dropped - this patch should preserve it.